### PR TITLE
Fixed nav-bar active classes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,7 @@
 // Your CSS partials
 @import "components/index";
 @import "pages/index";
+@import "pages/home";
+@import "components/alert";
+@import "components/navbar";
+@import "components/avatar";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def current_class?(test_path)
+    request.path == test_path ? "active" : "nav-item"
+  end
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,5 +1,5 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
-  <%= link_to "#", class: "navbar-brand" do %>
+  <%= link_to root_path, class: "navbar-brand" do %>
    <%= image_tag "logo.png" %>
     <% end %>
 
@@ -11,17 +11,28 @@
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <% if user_signed_in? %>
-        <li class="nav-item active">
-          <%= link_to "Home", "#", class: "nav-link" %>
+        <li class=<%= current_class?(root_path) %>>
+          <%= link_to "Home", root_path, class: "nav-link" %>
+        </li>
+        <li class=<%= current_class?(new_dream_path) %>>
+          <%= link_to "Host a dream", new_dream_path, class: "nav-link" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "Saved", "#", class: "nav-link" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "Upcoming dreams", "#", class: "nav-link" %>
         </li>
         <li class="nav-item">
           <%= link_to "Messages", "#", class: "nav-link" %>
         </li>
+        <li class="nav-item">
+          <%= link_to "Help", "#", class: "nav-link" %>
+        </li>
         <li class="nav-item dropdown">
           <%= image_tag "https://avatars3.githubusercontent.com/u/34791470?s=460&v=4", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-            <%= link_to "Action", "#", class: "dropdown-item" %>
-            <%= link_to "Another action", "#", class: "dropdown-item" %>
+            <%= link_to "Profile", edit_user_registration_path, class: "dropdown-item" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>
         </li>


### PR DESCRIPTION
I've created an active class checked for the active page and applied this to the navbar. Now we are able to set active class for the page that we are on. The pages that have not been created yet will still need to be added.

The avatar also needs setting to the active user.